### PR TITLE
Changed archetypes template to open resources links in a new tab

### DIFF
--- a/archetypes/Acid Trip.md
+++ b/archetypes/Acid Trip.md
@@ -54,8 +54,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Acid Trip 576.001.anynewprovince](https://www.mtggoldfish.com/deck/4351102) | Ravnica Allegiance | 2019-01-25 | ✅ |
-| [Acid Trip 576.001.AzoriusFlavoredGamerGirlPee](https://www.mtggoldfish.com/deck/4351103) | Ravnica Allegiance | 2019-01-25 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351102">Acid Trip 576.001.anynewprovince</a>  | Ravnica Allegiance | 2019-01-25 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351103">Acid Trip 576.001.AzoriusFlavoredGamerGirlPee</a>  | Ravnica Allegiance | 2019-01-25 | ✅ |
 
 
 

--- a/archetypes/Affinity.md
+++ b/archetypes/Affinity.md
@@ -69,16 +69,16 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Affinity 722.001.Oceansoul92](https://www.mtggoldfish.com/deck/4667094) | Kamigawa: Neon Dynasty | 2022-02-18 | Ban 🔨 |
-| [Affinity 722.001.Condescend](https://www.mtggoldfish.com/deck/4667095) | Kamigawa: Neon Dynasty | 2022-02-18 | Ban 🔨 |
-| [Affinity 676.003.Shika93](https://www.mtggoldfish.com/deck/4626261) | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
-| [Affinity 676.002.Shika93](https://www.mtggoldfish.com/deck/4626260) | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
-| [Affinity 676.002.MrEvilEye](https://www.mtggoldfish.com/deck/4351761) | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
-| [Affinity 676.001.Shika93](https://www.mtggoldfish.com/deck/4626259) | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
-| [Affinity 676.001.MrEvilEye](https://www.mtggoldfish.com/deck/4351762) | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
-| [Affinity 600.001.Shika93](https://www.mtggoldfish.com/deck/4626262) | Throne of Eldraine | 2019-10-04 | Ban 🔨 |
-| [Affinity 590.001.Shika93](https://www.mtggoldfish.com/deck/4626263) | Core Set 2020 | 2019-07-12 | Ban 🔨 |
-| [Affinity 501.001.Shika93](https://www.mtggoldfish.com/deck/4351744) | Hour of Devastation | 2017-07-14 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667094">Affinity 722.001.Oceansoul92</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667095">Affinity 722.001.Condescend</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4626261">Affinity 676.003.Shika93</a>  | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4626260">Affinity 676.002.Shika93</a>  | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351761">Affinity 676.002.MrEvilEye</a>  | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4626259">Affinity 676.001.Shika93</a>  | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351762">Affinity 676.001.MrEvilEye</a>  | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4626262">Affinity 600.001.Shika93</a>  | Throne of Eldraine | 2019-10-04 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4626263">Affinity 590.001.Shika93</a>  | Core Set 2020 | 2019-07-12 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351744">Affinity 501.001.Shika93</a>  | Hour of Devastation | 2017-07-14 | Ban 🔨 |
 
 
 

--- a/archetypes/Aristocrats.md
+++ b/archetypes/Aristocrats.md
@@ -56,7 +56,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Aristocrats 658.001.Gandalf_the_Magician](https://www.mtggoldfish.com/deck/4624331) | Kaldheim | 2021-02-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624331">Aristocrats 658.001.Gandalf_the_Magician</a>  | Kaldheim | 2021-02-05 | ✅ |
 
 
 
@@ -65,9 +65,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Aristocrats 676.001.MrEvilEye](https://www.mtggoldfish.com/deck/4351760) | Modern Horizons 2 | 2021-06-18 | ✅ |
-| [Aristocrats 669.001.sekiars](https://www.mtggoldfish.com/deck/4679882) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Aristocrats 501.001.Shika93](https://www.mtggoldfish.com/deck/4351745) | Hour of Devastation | 2017-07-14 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351760">Aristocrats 676.001.MrEvilEye</a>  | Modern Horizons 2 | 2021-06-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4679882">Aristocrats 669.001.sekiars</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351745">Aristocrats 501.001.Shika93</a>  | Hour of Devastation | 2017-07-14 | ✅ |
 
 
 

--- a/archetypes/Atog Shift.md
+++ b/archetypes/Atog Shift.md
@@ -37,7 +37,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Atog Shift 612.001.chumpblocckami](https://www.mtggoldfish.com/deck/4631338) | Theros Beyond Death | 2020-01-24 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4631338">Atog Shift 612.001.chumpblocckami</a>  | Theros Beyond Death | 2020-01-24 | Ban 🔨 |
 
 
 
@@ -46,7 +46,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Atog Shift 612.001.Arinaldo Ferreira](https://www.mtggoldfish.com/deck/4367487) | Theros Beyond Death | 2020-01-24 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4367487">Atog Shift 612.001.Arinaldo Ferreira</a>  | Theros Beyond Death | 2020-01-24 | Ban 🔨 |
 
 
 
@@ -57,5 +57,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [Report Winner Paupergeddon Milano 2020](http://pauperwave.altervista.org/2109-2/) | Matteo Mazzola | 2020-02-18   |
+| 🇮🇹 | <a target="_blank" href="http://pauperwave.altervista.org/2109-2/">Report Winner Paupergeddon Milano 2020</a>  | Matteo Mazzola | 2020-02-18   |
 

--- a/archetypes/Azorius Caw Blade.md
+++ b/archetypes/Azorius Caw Blade.md
@@ -53,8 +53,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Azorius Caw Blade 529.001.eternalgathering](https://www.mtggoldfish.com/deck/4351088) | Rivals of Ixalan | 2018-01-19 | ✅ |
-| [Azorius Caw Blade 493.001.gabripo93](https://www.mtggoldfish.com/deck/4351089) | Amonkhet | 2017-04-28 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351088">Azorius Caw Blade 529.001.eternalgathering</a>  | Rivals of Ixalan | 2018-01-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351089">Azorius Caw Blade 493.001.gabripo93</a>  | Amonkhet | 2017-04-28 | ✅ |
 
 
 
@@ -65,5 +65,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [UW Caw Blade – un midrange atipico](https://eternalgathering.altervista.org/caw-blade/) | eternalgathering | 2018-02-23   |
+| 🇮🇹 | <a target="_blank" href="https://eternalgathering.altervista.org/caw-blade/">UW Caw Blade – un midrange atipico</a>  | eternalgathering | 2018-02-23   |
 

--- a/archetypes/Azorius Evoke.md
+++ b/archetypes/Azorius Evoke.md
@@ -47,7 +47,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Azorius Evoke 696.001.Milkk](https://www.mtggoldfish.com/deck/4624440) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624440">Azorius Evoke 696.001.Milkk</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
 
 
 
@@ -56,7 +56,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Azorius Evoke 722.001.Milkk](https://www.mtggoldfish.com/deck/4624451) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624451">Azorius Evoke 722.001.Milkk</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 

--- a/archetypes/Black Burn.md
+++ b/archetypes/Black Burn.md
@@ -49,8 +49,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Black Burn 669.001.Ditoo](https://www.mtggoldfish.com/deck/4351116) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Black Burn 662.001.Grakon](https://www.mtggoldfish.com/deck/4351115) | Historic Anthology 4 | 2021-03-11 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351116">Black Burn 669.001.Ditoo</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351115">Black Burn 662.001.Grakon</a>  | Historic Anthology 4 | 2021-03-11 | ✅ |
 
 
 

--- a/archetypes/Bogles.md
+++ b/archetypes/Bogles.md
@@ -54,10 +54,10 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Bogles 683.001.SanPop](https://www.mtggoldfish.com/deck/4624393) | Adventures in the Forgotten Realms | 2021-07-23 | ✅ |
-| [Bogles 648.001.Mathonical](https://www.mtggoldfish.com/deck/4351127) | Zendikar Rising | 2020-09-25 | ✅ |
-| [Bogles 597.001.Mathonical](https://www.mtggoldfish.com/deck/4351071) | Commander 2019 | 2019-08-23 | Ban 🔨 |
-| [Bogles 584.001.TheMaverickGirl](https://www.mtggoldfish.com/deck/4351066) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624393">Bogles 683.001.SanPop</a>  | Adventures in the Forgotten Realms | 2021-07-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351127">Bogles 648.001.Mathonical</a>  | Zendikar Rising | 2020-09-25 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351071">Bogles 597.001.Mathonical</a>  | Commander 2019 | 2019-08-23 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351066">Bogles 584.001.TheMaverickGirl</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 
@@ -66,10 +66,10 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Bogles 722.001._DissonancE_](https://www.mtggoldfish.com/deck/4667099) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Bogles 722.001.Sarlanga](https://www.mtggoldfish.com/deck/4667113) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Bogles 722.001.Darthkid](https://www.mtggoldfish.com/deck/4667097) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Bogles 584.001.Jail0Breaker](https://www.mtggoldfish.com/deck/4351056) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667099">Bogles 722.001._DissonancE_</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667113">Bogles 722.001.Sarlanga</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667097">Bogles 722.001.Darthkid</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351056">Bogles 584.001.Jail0Breaker</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 
@@ -80,5 +80,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [[Pauper Tier] Aura Hexproof](http://www.metagame.it/forum/viewtopic.php?f=158&t=24491) | DaveSpace | 2011-12-27   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=158&t=24491">[Pauper Tier] Aura Hexproof</a>  | DaveSpace | 2011-12-27   |
 

--- a/archetypes/Boros Bully.md
+++ b/archetypes/Boros Bully.md
@@ -52,8 +52,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Boros Bully 669.001.Heisen01](https://www.mtggoldfish.com/deck/4618626) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Boros Bully 576.001.deluxeicoff](https://www.mtggoldfish.com/deck/4351052) | Ravnica Allegiance | 2019-01-25 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618626">Boros Bully 669.001.Heisen01</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351052">Boros Bully 576.001.deluxeicoff</a>  | Ravnica Allegiance | 2019-01-25 | ✅ |
 
 
 
@@ -62,9 +62,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Boros Bully 722.001.Lumbalgic](https://www.mtggoldfish.com/deck/4667096) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Boros Bully 722.001.Lollopollo2001](https://www.mtggoldfish.com/deck/4620538) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Boros Bully 669.001.Franco Cicchini](https://www.mtggoldfish.com/deck/4351118) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667096">Boros Bully 722.001.Lumbalgic</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4620538">Boros Bully 722.001.Lollopollo2001</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351118">Boros Bully 669.001.Franco Cicchini</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
 
 
 

--- a/archetypes/Boros Monarch.md
+++ b/archetypes/Boros Monarch.md
@@ -57,8 +57,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Boros Monarch 696.001.carvs](https://www.mtggoldfish.com/deck/4624426) | Innistrad: Midnight Hunt | 2021-09-24 | Ban 🔨 |
-| [Boros Monarch 560.001.Thraben27](https://www.mtggoldfish.com/deck/4351053) | Guilds of Ravnica | 2018-10-05 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624426">Boros Monarch 696.001.carvs</a>  | Innistrad: Midnight Hunt | 2021-09-24 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351053">Boros Monarch 560.001.Thraben27</a>  | Guilds of Ravnica | 2018-10-05 | Ban 🔨 |
 
 
 
@@ -67,8 +67,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Boros Monarch 658.001.Rsousa](https://www.mtggoldfish.com/deck/4351119) | Kaldheim | 2021-02-05 | Ban 🔨 |
-| [Boros Monarch 658.001.Chronicle](https://www.mtggoldfish.com/deck/4351120) | Kaldheim | 2021-02-05 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351119">Boros Monarch 658.001.Rsousa</a>  | Kaldheim | 2021-02-05 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351120">Boros Monarch 658.001.Chronicle</a>  | Kaldheim | 2021-02-05 | Ban 🔨 |
 
 
 

--- a/archetypes/Brute Squad.md
+++ b/archetypes/Brute Squad.md
@@ -20,7 +20,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Brute Squad 658.001.Luiz0211](https://www.mtggoldfish.com/deck/4351093) | Kaldheim | 2021-02-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351093">Brute Squad 658.001.Luiz0211</a>  | Kaldheim | 2021-02-05 | ✅ |
 
 
 
@@ -31,5 +31,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Deck Guide: Pauper Brute Squad](https://strategy.channelfireball.com/all-strategy/home/deck-guide-pauper-brute-squad/) | Alex Ullman | 2021-04-09   |
+| 🇬🇧 | <a target="_blank" href="https://strategy.channelfireball.com/all-strategy/home/deck-guide-pauper-brute-squad/">Deck Guide: Pauper Brute Squad</a>  | Alex Ullman | 2021-04-09   |
 

--- a/archetypes/Burn.md
+++ b/archetypes/Burn.md
@@ -48,8 +48,8 @@ Tough decisions for Burn players also involve choosing whether to use removals o
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Burn 696.001.PRGJJAR](https://www.mtggoldfish.com/deck/4624409) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
-| [Burn 584.001.SuperCow12653](https://www.mtggoldfish.com/deck/4351060) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624409">Burn 696.001.PRGJJAR</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351060">Burn 584.001.SuperCow12653</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 
@@ -58,10 +58,10 @@ Tough decisions for Burn players also involve choosing whether to use removals o
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Burn 722.001.davy2892](https://www.mtggoldfish.com/deck/4682095) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Burn 722.001.John1111](https://www.mtggoldfish.com/deck/4667101) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Burn 676.001.MrEvilEye](https://www.mtggoldfish.com/deck/4351765) | Modern Horizons 2 | 2021-06-18 | ✅ |
-| [Burn 560.001.Shika93](https://www.mtggoldfish.com/deck/4351742) | Guilds of Ravnica | 2018-10-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4682095">Burn 722.001.davy2892</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667101">Burn 722.001.John1111</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351765">Burn 676.001.MrEvilEye</a>  | Modern Horizons 2 | 2021-06-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351742">Burn 560.001.Shika93</a>  | Guilds of Ravnica | 2018-10-05 | ✅ |
 
 
 
@@ -72,5 +72,5 @@ Tough decisions for Burn players also involve choosing whether to use removals o
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [A Guide to Mono-Red Burn in Pauper](https://strategy.channelfireball.com/all-strategy/mtg/channelmagic-articles/a-guide-to-mono-red-burn-in-pauper/) | Martin Juza | 2019-11-01   |
+| 🇬🇧 | <a target="_blank" href="https://strategy.channelfireball.com/all-strategy/mtg/channelmagic-articles/a-guide-to-mono-red-burn-in-pauper/">A Guide to Mono-Red Burn in Pauper</a>  | Martin Juza | 2019-11-01   |
 

--- a/archetypes/Canadian Threshold.md
+++ b/archetypes/Canadian Threshold.md
@@ -59,10 +59,10 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Canadian Threshold 518.001.eternalgathering](https://www.mtggoldfish.com/deck/4351079) | Iconic Masters | 2017-11-17 | Ban 🔨 |
-| [Canadian Threshold 488.002.Federico Vaglio](https://www.mtggoldfish.com/deck/4351957) | Modern Masters 2017 | 2017-03-17 | Ban 🔨 |
-| [Canadian Threshold 488.001.alwayshalfchub](https://www.mtggoldfish.com/deck/4351076) | Modern Masters 2017 | 2017-03-17 | ✅ |
-| [Canadian Threshold 488.001.Federico Vaglio](https://www.mtggoldfish.com/deck/4351949) | Modern Masters 2017 | 2017-03-17 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351079">Canadian Threshold 518.001.eternalgathering</a>  | Iconic Masters | 2017-11-17 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351957">Canadian Threshold 488.002.Federico Vaglio</a>  | Modern Masters 2017 | 2017-03-17 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351076">Canadian Threshold 488.001.alwayshalfchub</a>  | Modern Masters 2017 | 2017-03-17 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351949">Canadian Threshold 488.001.Federico Vaglio</a>  | Modern Masters 2017 | 2017-03-17 | Ban 🔨 |
 
 
 
@@ -73,7 +73,7 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [The Canadian Job, ovvero la grande bellezza](https://eternalgathering.altervista.org/the-canadian-job-ovvero-la-grande-bellezza/) | eternalgathering | 2017-11-17   |
-| 🇬🇧 | [Pauper Ponderings: Canadian Threshold](http://themanabase.wpengine.com/pauper-ponderings-canadian-threshold/) | Austen Hoey | 2017-04-27   |
-| 🇮🇹 | [CANADIAN THRESHOLD](https://paupernexus.wixsite.com/paupernexus/primer-canadian-threshold) | Federico Vaglio | 2016-06-15   |
+| 🇮🇹 | <a target="_blank" href="https://eternalgathering.altervista.org/the-canadian-job-ovvero-la-grande-bellezza/">The Canadian Job, ovvero la grande bellezza</a>  | eternalgathering | 2017-11-17   |
+| 🇬🇧 | <a target="_blank" href="http://themanabase.wpengine.com/pauper-ponderings-canadian-threshold/">Pauper Ponderings: Canadian Threshold</a>  | Austen Hoey | 2017-04-27   |
+| 🇮🇹 | <a target="_blank" href="https://paupernexus.wixsite.com/paupernexus/primer-canadian-threshold">CANADIAN THRESHOLD</a>  | Federico Vaglio | 2016-06-15   |
 

--- a/archetypes/Chatterstorm.md
+++ b/archetypes/Chatterstorm.md
@@ -52,9 +52,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Chatterstorm 676.003.gannoncd](https://www.mtggoldfish.com/deck/4351145) | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
-| [Chatterstorm 676.002.gannoncd](https://www.mtggoldfish.com/deck/4351144) | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
-| [Chatterstorm 676.001.gannoncd](https://www.mtggoldfish.com/deck/4351143) | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351145">Chatterstorm 676.003.gannoncd</a>  | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351144">Chatterstorm 676.002.gannoncd</a>  | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351143">Chatterstorm 676.001.gannoncd</a>  | Modern Horizons 2 | 2021-06-18 | Ban 🔨 |
 
 
 

--- a/archetypes/Cycling Storm.md
+++ b/archetypes/Cycling Storm.md
@@ -50,8 +50,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Cycling Storm 701.001.Vivarus](https://www.mtggoldfish.com/deck/4618670) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
-| [Cycling Storm 696.001.Bryant_Cook](https://www.mtggoldfish.com/deck/4624384) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618670">Cycling Storm 701.001.Vivarus</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624384">Cycling Storm 696.001.Bryant_Cook</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
 
 
 
@@ -64,6 +64,6 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Storm Discord](https://discord.gg/zrn2N6HT) | <i class="fa-brands fa-discord"></i> | ~            |
-| 🇬🇧 | [PAUPER CYCLE STORM PRIMER](https://www.theepicstorm.com/pauper-cycle-storm-primer/) | Alex McKinley | 2022-01-30   |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/zrn2N6HT">Pauper Storm Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://www.theepicstorm.com/pauper-cycle-storm-primer/">PAUPER CYCLE STORM PRIMER</a>  | Alex McKinley | 2022-01-30   |
 

--- a/archetypes/Dimir Alchemy.md
+++ b/archetypes/Dimir Alchemy.md
@@ -57,9 +57,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Dimir Alchemy 612.001.MrEvilEye](https://www.mtggoldfish.com/deck/4351767) | Theros Beyond Death | 2020-01-24 | ✅ |
-| [Dimir Alchemy 560.001.Simone Capuzzi](https://www.mtggoldfish.com/deck/4351083) | Guilds of Ravnica | 2018-10-05 | ✅ |
-| [Dimir Alchemy 529.001.The Professor (Brian Lewis)](https://www.mtggoldfish.com/deck/4351133) | Rivals of Ixalan | 2018-01-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351767">Dimir Alchemy 612.001.MrEvilEye</a>  | Theros Beyond Death | 2020-01-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351083">Dimir Alchemy 560.001.Simone Capuzzi</a>  | Guilds of Ravnica | 2018-10-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351133">Dimir Alchemy 529.001.The Professor (Brian Lewis)</a>  | Rivals of Ixalan | 2018-01-19 | ✅ |
 
 
 

--- a/archetypes/Dimir Delver.md
+++ b/archetypes/Dimir Delver.md
@@ -54,7 +54,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Dimir Delver 648.001.Hamuda](https://www.mtggoldfish.com/deck/4351124) | Zendikar Rising | 2020-09-25 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351124">Dimir Delver 648.001.Hamuda</a>  | Zendikar Rising | 2020-09-25 | ✅ |
 
 
 
@@ -63,7 +63,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Dimir Delver 584.001.MTGPRO69](https://www.mtggoldfish.com/deck/4351058) | War of the Spark | 2019-05-03 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351058">Dimir Delver 584.001.MTGPRO69</a>  | War of the Spark | 2019-05-03 | Ban 🔨 |
 
 
 
@@ -74,5 +74,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [[Pauper Tier] Dimir Delver](http://www.metagame.it/forum/viewtopic.php?f=158&t=16467) | Siol | 2013-02-05   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=158&t=16467">[Pauper Tier] Dimir Delver</a>  | Siol | 2013-02-05   |
 

--- a/archetypes/Dimir Faeries.md
+++ b/archetypes/Dimir Faeries.md
@@ -51,7 +51,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Dimir Faeries 696.001.Beicodegeia](https://www.mtggoldfish.com/deck/4624287) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624287">Dimir Faeries 696.001.Beicodegeia</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
 
 
 
@@ -60,8 +60,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Dimir Faeries 669.001.MrEvilEye](https://www.mtggoldfish.com/deck/4351763) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Dimir Faeries 669.001.Matteo Lugli](https://www.mtggoldfish.com/deck/4351114) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351763">Dimir Faeries 669.001.MrEvilEye</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351114">Dimir Faeries 669.001.Matteo Lugli</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
 
 
 

--- a/archetypes/Dimir Flicker.md
+++ b/archetypes/Dimir Flicker.md
@@ -52,8 +52,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Dimir Flicker 722.001.DragonDayDragon](https://www.mtggoldfish.com/deck/4673151) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Dimir Flicker 701.001.hjc](https://www.mtggoldfish.com/deck/4673152) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673151">Dimir Flicker 722.001.DragonDayDragon</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673152">Dimir Flicker 701.001.hjc</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
 
 
 

--- a/archetypes/Dimir Reanimator.md
+++ b/archetypes/Dimir Reanimator.md
@@ -53,8 +53,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Dimir Reanimator 722.001.Bryant_Cook](https://www.mtggoldfish.com/deck/4673153) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Dimir Reanimator 701.001.monkey_noises](https://www.mtggoldfish.com/deck/4673154) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673153">Dimir Reanimator 722.001.Bryant_Cook</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673154">Dimir Reanimator 701.001.monkey_noises</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
 
 
 

--- a/archetypes/Dimir Teachings.md
+++ b/archetypes/Dimir Teachings.md
@@ -68,8 +68,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Dimir Teachings 454.001.Jake Stiles](https://www.mtggoldfish.com/deck/4351084) | Oath of the Gatewatch | 2016-01-22 | ✅ |
-| [Dimir Teachings 454.001.Caiusthethief](https://www.mtggoldfish.com/deck/4351085) | Oath of the Gatewatch | 2016-01-22 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351084">Dimir Teachings 454.001.Jake Stiles</a>  | Oath of the Gatewatch | 2016-01-22 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351085">Dimir Teachings 454.001.Caiusthethief</a>  | Oath of the Gatewatch | 2016-01-22 | ✅ |
 
 
 
@@ -80,6 +80,6 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Playing Pauper: Dimir Teachings](https://www.mtggoldfish.com/articles/playing-pauper-dimir-teachings) | Jake Stiles | 2016-03-30   |
-| 🇮🇹 | [DECK ANALISI - UB TEACHINGS IN PAUPER](http://www.metagame.it/articoli-pauper/1730-deck-analisi-ub-teachings.html) | Giorgio "Caiusthethief" Iaderosa | 2016-01-31   |
+| 🇬🇧 | <a target="_blank" href="https://www.mtggoldfish.com/articles/playing-pauper-dimir-teachings">Playing Pauper: Dimir Teachings</a>  | Jake Stiles | 2016-03-30   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/articoli-pauper/1730-deck-analisi-ub-teachings.html">DECK ANALISI - UB TEACHINGS IN PAUPER</a>  | Giorgio "Caiusthethief" Iaderosa | 2016-01-31   |
 

--- a/archetypes/Domain Zoo.md
+++ b/archetypes/Domain Zoo.md
@@ -51,8 +51,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Domain Zoo 722.001.Nessin](https://www.mtggoldfish.com/deck/4673793) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Domain Zoo 701.001.Jacaretinga](https://www.mtggoldfish.com/deck/4673160) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673793">Domain Zoo 722.001.Nessin</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673160">Domain Zoo 701.001.Jacaretinga</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
 
 
 

--- a/archetypes/Eggs.md
+++ b/archetypes/Eggs.md
@@ -52,9 +52,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Eggs 533.001.fedetoro](https://www.mtggoldfish.com/deck/4351104) | Masters 25 | 2018-03-16 | Ban 🔨 |
-| [Eggs 518.002.Shika93](https://www.mtggoldfish.com/deck/4351757) | Iconic Masters | 2017-11-17 | Ban 🔨 |
-| [Eggs 518.001.Shika93](https://www.mtggoldfish.com/deck/4351755) | Iconic Masters | 2017-11-17 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351104">Eggs 533.001.fedetoro</a>  | Masters 25 | 2018-03-16 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351757">Eggs 518.002.Shika93</a>  | Iconic Masters | 2017-11-17 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351755">Eggs 518.001.Shika93</a>  | Iconic Masters | 2017-11-17 | Ban 🔨 |
 
 
 
@@ -65,5 +65,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [BUILDING ON A BUDGET: PAUPER EGGS](http://www.metagame.it/articoli-pauper/3341-building-on-a-budget-pauper-eggs.html) | Federico Cazzaniga - fedetoro | 2018-03-30   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/articoli-pauper/3341-building-on-a-budget-pauper-eggs.html">BUILDING ON A BUDGET: PAUPER EGGS</a>  | Federico Cazzaniga - fedetoro | 2018-03-30   |
 

--- a/archetypes/Elves.md
+++ b/archetypes/Elves.md
@@ -51,9 +51,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Elves 696.001.tarmogoyf_ita](https://www.mtggoldfish.com/deck/4624413) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
-| [Elves 576.001.TheMaverickGal](https://www.mtggoldfish.com/deck/4351055) | Ravnica Allegiance | 2019-01-25 | ✅ |
-| [Elves 560.001.TheMaverickGal](https://www.mtggoldfish.com/deck/4351054) | Guilds of Ravnica | 2018-10-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624413">Elves 696.001.tarmogoyf_ita</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351055">Elves 576.001.TheMaverickGal</a>  | Ravnica Allegiance | 2019-01-25 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351054">Elves 560.001.TheMaverickGal</a>  | Guilds of Ravnica | 2018-10-05 | ✅ |
 
 
 
@@ -62,7 +62,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Elves 722.001.tarmogoyf_ita](https://www.mtggoldfish.com/deck/4667110) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667110">Elves 722.001.tarmogoyf_ita</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 
@@ -73,6 +73,6 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Elves Discord](https://discord.gg/JukzE4x4) | <i class="fa-brands fa-discord"></i> | ~            |
-| 🇮🇹 | [[Pauper Tier] Elves](http://www.metagame.it/forum/viewtopic.php?f=158&t=5180) | Kuraiden | 2012-05-17   |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/JukzE4x4">Pauper Elves Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=158&t=5180">[Pauper Tier] Elves</a>  | Kuraiden | 2012-05-17   |
 

--- a/archetypes/Familiars.md
+++ b/archetypes/Familiars.md
@@ -59,8 +59,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Familiars 696.001.Finespoo](https://www.mtggoldfish.com/deck/4624361) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
-| [Familiars 533.001.A_AdeptoTerra](https://www.mtggoldfish.com/deck/4351105) | Masters 25 | 2018-03-16 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624361">Familiars 696.001.Finespoo</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351105">Familiars 533.001.A_AdeptoTerra</a>  | Masters 25 | 2018-03-16 | Ban 🔨 |
 
 
 
@@ -69,10 +69,10 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Familiars 722.001.Tinkmaster](https://www.mtggoldfish.com/deck/4667098) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Familiars 584.003.420Dragon](https://www.mtggoldfish.com/deck/4351067) | War of the Spark | 2019-05-03 | ✅ |
-| [Familiars 584.002.420Dragon](https://www.mtggoldfish.com/deck/4351065) | War of the Spark | 2019-05-03 | ✅ |
-| [Familiars 584.001.420Dragon](https://www.mtggoldfish.com/deck/4351064) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667098">Familiars 722.001.Tinkmaster</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351067">Familiars 584.003.420Dragon</a>  | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351065">Familiars 584.002.420Dragon</a>  | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351064">Familiars 584.001.420Dragon</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 
@@ -83,8 +83,8 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Familiars Discord](https://discord.gg/ANYVTjTf) | <i class="fa-brands fa-discord"></i> | ~            |
-| 🇬🇧 | [UW Familiars HOW TO and sideboarding guide](https://www.youtube.com/watch?v=aBjW1lKdrYo&t=1s) | kalikaiz | 2021-12-07   |
-| 🇮🇹 | [UW Familiar Pauper League](http://pauperwave.altervista.org/uw-familiar-pauper-league/) | Alessandro Moretti | 2020-04-01   |
-| 🇬🇧 | [Familiar speed tutorial with 420dragon](https://www.youtube.com/watch?v=59P3zGL_54A) | 420dragon | 2017-12-22   |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/ANYVTjTf">Pauper Familiars Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://www.youtube.com/watch?v=aBjW1lKdrYo&t=1s">UW Familiars HOW TO and sideboarding guide</a>  | kalikaiz | 2021-12-07   |
+| 🇮🇹 | <a target="_blank" href="http://pauperwave.altervista.org/uw-familiar-pauper-league/">UW Familiar Pauper League</a>  | Alessandro Moretti | 2020-04-01   |
+| 🇬🇧 | <a target="_blank" href="https://www.youtube.com/watch?v=59P3zGL_54A">Familiar speed tutorial with 420dragon</a>  | 420dragon | 2017-12-22   |
 

--- a/archetypes/Fishelbrand.md
+++ b/archetypes/Fishelbrand.md
@@ -54,7 +54,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Fishelbrand 600.003.gannoncd](https://www.mtggoldfish.com/deck/4351094) | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351094">Fishelbrand 600.003.gannoncd</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
 
 
 
@@ -63,8 +63,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Fishelbrand 600.002.gannoncd](https://www.mtggoldfish.com/deck/4351096) | Throne of Eldraine | 2019-10-04 | ✅ |
-| [Fishelbrand 600.001.gannoncd](https://www.mtggoldfish.com/deck/4351095) | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351096">Fishelbrand 600.002.gannoncd</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351095">Fishelbrand 600.001.gannoncd</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
 
 
 

--- a/archetypes/Flicker Tron.md
+++ b/archetypes/Flicker Tron.md
@@ -64,7 +64,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Flicker Tron 612.001.A_AdeptoTerra](https://www.mtggoldfish.com/deck/4351075) | Theros Beyond Death | 2020-01-24 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351075">Flicker Tron 612.001.A_AdeptoTerra</a>  | Theros Beyond Death | 2020-01-24 | Ban 🔨 |
 
 
 
@@ -73,11 +73,11 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Flicker Tron 651.001.Milkk](https://www.mtggoldfish.com/deck/4351122) | Commander Legends | 2020-11-20 | Ban 🔨 |
-| [Flicker Tron 576.001.Patrick](https://www.mtggoldfish.com/deck/4351070) | Ravnica Allegiance | 2019-01-25 | Ban 🔨 |
-| [Flicker Tron 576.001.Mathonical](https://www.mtggoldfish.com/deck/4351069) | Ravnica Allegiance | 2019-01-25 | Ban 🔨 |
-| [Flicker Tron 576.001.Birbman263](https://www.mtggoldfish.com/deck/4351068) | Ravnica Allegiance | 2019-01-25 | Ban 🔨 |
-| [Flicker Tron 560.001.Birbman263](https://www.mtggoldfish.com/deck/4351051) | Guilds of Ravnica | 2018-10-05 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351122">Flicker Tron 651.001.Milkk</a>  | Commander Legends | 2020-11-20 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351070">Flicker Tron 576.001.Patrick</a>  | Ravnica Allegiance | 2019-01-25 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351069">Flicker Tron 576.001.Mathonical</a>  | Ravnica Allegiance | 2019-01-25 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351068">Flicker Tron 576.001.Birbman263</a>  | Ravnica Allegiance | 2019-01-25 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351051">Flicker Tron 560.001.Birbman263</a>  | Guilds of Ravnica | 2018-10-05 | Ban 🔨 |
 
 
 

--- a/archetypes/Goblins.md
+++ b/archetypes/Goblins.md
@@ -56,7 +56,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Goblins 669.001.mosskirin](https://www.mtggoldfish.com/deck/4624419) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624419">Goblins 669.001.mosskirin</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
 
 
 
@@ -65,9 +65,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Goblins 669.001.ZeMotinha](https://www.mtggoldfish.com/deck/4351140) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Goblins 669.001.Jeremiaa](https://www.mtggoldfish.com/deck/4351139) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Goblins 600.001.walterr25](https://www.mtggoldfish.com/deck/4351073) | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351140">Goblins 669.001.ZeMotinha</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351139">Goblins 669.001.Jeremiaa</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351073">Goblins 600.001.walterr25</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
 
 
 

--- a/archetypes/Golgari TortEx.md
+++ b/archetypes/Golgari TortEx.md
@@ -61,9 +61,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Golgari TortEx 669.001.Shika93](https://www.mtggoldfish.com/deck/4351733) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Golgari TortEx 600.001.Shika93](https://www.mtggoldfish.com/deck/4351750) | Throne of Eldraine | 2019-10-04 | ✅ |
-| [Golgari TortEx 537.001.Shika93](https://www.mtggoldfish.com/deck/4351741) | Dominaria | 2018-04-27 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351733">Golgari TortEx 669.001.Shika93</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351750">Golgari TortEx 600.001.Shika93</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351741">Golgari TortEx 537.001.Shika93</a>  | Dominaria | 2018-04-27 | ✅ |
 
 
 
@@ -74,5 +74,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper TortEx Discord](https://discord.gg/fRzwk2TJ) | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/fRzwk2TJ">Pauper TortEx Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
 

--- a/archetypes/Infect.md
+++ b/archetypes/Infect.md
@@ -49,8 +49,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Infect 722.001.Sorceress-Queen](https://www.mtggoldfish.com/deck/4667112) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Infect 722.001.Luca_Borghesi](https://www.mtggoldfish.com/deck/4673155) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667112">Infect 722.001.Sorceress-Queen</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673155">Infect 722.001.Luca_Borghesi</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 
@@ -61,5 +61,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [[Pauper Tier] Infect](http://www.metagame.it/forum/viewtopic.php?f=158&t=26111) | Dave Space | 2011-12-27   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=158&t=26111">[Pauper Tier] Infect</a>  | Dave Space | 2011-12-27   |
 

--- a/archetypes/Inside Out.md
+++ b/archetypes/Inside Out.md
@@ -65,10 +65,10 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Inside Out 701.001.carvs](https://www.mtggoldfish.com/deck/4618617) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
-| [Inside Out 612.001.Mathonical](https://www.mtggoldfish.com/deck/4351128) | Theros Beyond Death | 2020-01-24 | Ban 🔨 |
-| [Inside Out 600.001.A_AdeptoTerra](https://www.mtggoldfish.com/deck/4351072) | Throne of Eldraine | 2019-10-04 | ✅ |
-| [Inside Out 584.001.Entropy263](https://www.mtggoldfish.com/deck/4351063) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618617">Inside Out 701.001.carvs</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351128">Inside Out 612.001.Mathonical</a>  | Theros Beyond Death | 2020-01-24 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351072">Inside Out 600.001.A_AdeptoTerra</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351063">Inside Out 584.001.Entropy263</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 
@@ -77,9 +77,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Inside Out 722.001.neoweapon](https://www.mtggoldfish.com/deck/4673785) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Inside Out 722.001.Venancioo](https://www.mtggoldfish.com/deck/4673784) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Inside Out 540.001.Shika93](https://www.mtggoldfish.com/deck/4351737) | Battlebond | 2018-06-08 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673785">Inside Out 722.001.neoweapon</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673784">Inside Out 722.001.Venancioo</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351737">Inside Out 540.001.Shika93</a>  | Battlebond | 2018-06-08 | Ban 🔨 |
 
 
 
@@ -90,5 +90,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [Pauper Report - UW Tribe @ Paupergeddon](http://www.metagame.it/articoli-pauper/3407-pauper-report-uw-tribe-paupergeddon.html) | Pietro Bragioto | 2018-07-10   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/articoli-pauper/3407-pauper-report-uw-tribe-paupergeddon.html">Pauper Report - UW Tribe @ Paupergeddon</a>  | Pietro Bragioto | 2018-07-10   |
 

--- a/archetypes/Izzet Blitz.md
+++ b/archetypes/Izzet Blitz.md
@@ -51,7 +51,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Izzet Blitz 584.001.Amoras27](https://www.mtggoldfish.com/deck/4351062) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351062">Izzet Blitz 584.001.Amoras27</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 
@@ -60,8 +60,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Izzet Blitz 722.001.Amoras27](https://www.mtggoldfish.com/deck/4667106) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Izzet Blitz 479.001.gabripo93](https://www.mtggoldfish.com/deck/4351123) | Treasure Chest | 2016-11-16 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667106">Izzet Blitz 722.001.Amoras27</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351123">Izzet Blitz 479.001.gabripo93</a>  | Treasure Chest | 2016-11-16 | Ban 🔨 |
 
 
 

--- a/archetypes/Izzet Curve.md
+++ b/archetypes/Izzet Curve.md
@@ -60,7 +60,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Izzet Curve 676.001.killersuv](https://www.mtggoldfish.com/deck/4351129) | Modern Horizons 2 | 2021-06-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351129">Izzet Curve 676.001.killersuv</a>  | Modern Horizons 2 | 2021-06-18 | ✅ |
 
 
 
@@ -69,8 +69,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Izzet Curve 701.001.GiorgioCombo](https://www.mtggoldfish.com/deck/4679883) | Innistrad: Crimson Vow | 2021-11-19 | Ban 🔨 |
-| [Izzet Curve 676.001._INVISIBLEKID_](https://www.mtggoldfish.com/deck/4351130) | Modern Horizons 2 | 2021-06-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4679883">Izzet Curve 701.001.GiorgioCombo</a>  | Innistrad: Crimson Vow | 2021-11-19 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351130">Izzet Curve 676.001._INVISIBLEKID_</a>  | Modern Horizons 2 | 2021-06-18 | ✅ |
 
 
 
@@ -81,5 +81,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Storm Discord](https://discord.gg/zrn2N6HT) | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/zrn2N6HT">Pauper Storm Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
 

--- a/archetypes/Izzet Faeries.md
+++ b/archetypes/Izzet Faeries.md
@@ -52,7 +52,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Izzet Faeries 696.001.Mogged](https://www.mtggoldfish.com/deck/4624370) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624370">Izzet Faeries 696.001.Mogged</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
 
 
 
@@ -61,11 +61,11 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Izzet Faeries 722.001.Izzet Faeries](https://www.mtggoldfish.com/deck/4667117) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Izzet Faeries 676.002.MrEvilEye](https://www.mtggoldfish.com/deck/4351766) | Modern Horizons 2 | 2021-06-18 | ✅ |
-| [Izzet Faeries 676.001.MrEvilEye](https://www.mtggoldfish.com/deck/4351764) | Modern Horizons 2 | 2021-06-18 | ✅ |
-| [Izzet Faeries 584.001.PIETART](https://www.mtggoldfish.com/deck/4351057) | War of the Spark | 2019-05-03 | Ban 🔨 |
-| [Izzet Faeries 584.001.Mengucci](https://www.mtggoldfish.com/deck/4351059) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667117">Izzet Faeries 722.001.Izzet Faeries</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351766">Izzet Faeries 676.002.MrEvilEye</a>  | Modern Horizons 2 | 2021-06-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351764">Izzet Faeries 676.001.MrEvilEye</a>  | Modern Horizons 2 | 2021-06-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351057">Izzet Faeries 584.001.PIETART</a>  | War of the Spark | 2019-05-03 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351059">Izzet Faeries 584.001.Mengucci</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 
@@ -76,5 +76,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [[Pauper Tier] Izzet Delver](http://www.metagame.it/forum/viewtopic.php?f=158&t=18321) | Allen | 2013-08-22   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=158&t=18321">[Pauper Tier] Izzet Delver</a>  | Allen | 2013-08-22   |
 

--- a/archetypes/Jeskai Ephemerate.md
+++ b/archetypes/Jeskai Ephemerate.md
@@ -48,8 +48,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Jeskai Ephemerate 722.002.ziofrancone](https://www.mtggoldfish.com/deck/4667283) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Jeskai Ephemerate 722.001.ziofrancone](https://www.mtggoldfish.com/deck/4667282) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667283">Jeskai Ephemerate 722.002.ziofrancone</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667282">Jeskai Ephemerate 722.001.ziofrancone</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 

--- a/archetypes/Jeskai Snow.md
+++ b/archetypes/Jeskai Snow.md
@@ -47,8 +47,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Jeskai Snow 600.001.Thebiologist](https://www.mtggoldfish.com/deck/4673181) | Throne of Eldraine | 2019-10-04 | Ban 🔨 |
-| [Jeskai Snow 600.001.Backoff](https://www.mtggoldfish.com/deck/4673180) | Throne of Eldraine | 2019-10-04 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673181">Jeskai Snow 600.001.Thebiologist</a>  | Throne of Eldraine | 2019-10-04 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673180">Jeskai Snow 600.001.Backoff</a>  | Throne of Eldraine | 2019-10-04 | Ban 🔨 |
 
 
 

--- a/archetypes/Jund Cascade.md
+++ b/archetypes/Jund Cascade.md
@@ -51,7 +51,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Jund Cascade 701.001.Ixidor29](https://www.mtggoldfish.com/deck/4620537) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4620537">Jund Cascade 701.001.Ixidor29</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
 
 
 
@@ -60,7 +60,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Jund Cascade 658.001.Milkk](https://www.mtggoldfish.com/deck/4351121) | Kaldheim | 2021-02-05 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351121">Jund Cascade 658.001.Milkk</a>  | Kaldheim | 2021-02-05 | Ban 🔨 |
 
 
 
@@ -71,5 +71,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Cascade Discord](https://discord.gg/2qf7KsVE) | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/2qf7KsVE">Pauper Cascade Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
 

--- a/archetypes/Jund Gardens.md
+++ b/archetypes/Jund Gardens.md
@@ -40,8 +40,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Jund Gardens 722.002.Milkk](https://www.mtggoldfish.com/deck/4675385) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Jund Gardens 722.001.Milkk](https://www.mtggoldfish.com/deck/4675387) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4675385">Jund Gardens 722.002.Milkk</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4675387">Jund Gardens 722.001.Milkk</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 

--- a/archetypes/Jund PhD.md
+++ b/archetypes/Jund PhD.md
@@ -37,9 +37,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Jund PhD 669.002.Milkk](https://www.mtggoldfish.com/deck/4351136) | Strixhaven: School of Mages | 2021-04-23 | Ban 🔨 |
-| [Jund PhD 669.001.Milkk](https://www.mtggoldfish.com/deck/4351135) | Strixhaven: School of Mages | 2021-04-23 | Ban 🔨 |
-| [Jund PhD 669.001.CooperTheRed](https://www.mtggoldfish.com/deck/4351134) | Strixhaven: School of Mages | 2021-04-23 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351136">Jund PhD 669.002.Milkk</a>  | Strixhaven: School of Mages | 2021-04-23 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351135">Jund PhD 669.001.Milkk</a>  | Strixhaven: School of Mages | 2021-04-23 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351134">Jund PhD 669.001.CooperTheRed</a>  | Strixhaven: School of Mages | 2021-04-23 | Ban 🔨 |
 
 
 

--- a/archetypes/Kuldotha Rebirth.md
+++ b/archetypes/Kuldotha Rebirth.md
@@ -47,7 +47,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Kuldotha Rebirth 722.001.Tarrasque1](https://www.mtggoldfish.com/deck/4618362) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618362">Kuldotha Rebirth 722.001.Tarrasque1</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 
@@ -56,7 +56,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Kuldotha Rebirth 459.001.JakeStiles](https://www.mtggoldfish.com/deck/4618615) | Shadows over Innistrad | 2016-04-08 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618615">Kuldotha Rebirth 459.001.JakeStiles</a>  | Shadows over Innistrad | 2016-04-08 | Ban 🔨 |
 
 
 
@@ -65,8 +65,8 @@
 
 | 🗣️ | 📺 | Deck | Author | Date |
 | -- | -- | ---- | ------ | ---- |
-| 🇬🇧 | <i class="fa-brands fa-youtube"></i> | [Kuldotha Rebirth 722.001.Tarrasque1](https://www.youtube.com/watch?v=5JBC2EhjGdM) | Pauperformance | 2022-03-20   |
-| 🇬🇧 | <i class="fa-brands fa-youtube"></i> | [Kuldotha Rebirth 722.001.Tarrasque1](https://www.youtube.com/watch?v=gqPuvf0OzKY) | Pauperformance | 2022-03-16   |
+| 🇬🇧 | <i class="fa-brands fa-youtube"></i> | <a target="_blank" href="https://www.youtube.com/watch?v=5JBC2EhjGdM">Kuldotha Rebirth 722.001.Tarrasque1</a> | Pauperformance | 2022-03-20   |
+| 🇬🇧 | <i class="fa-brands fa-youtube"></i> | <a target="_blank" href="https://www.youtube.com/watch?v=gqPuvf0OzKY">Kuldotha Rebirth 722.001.Tarrasque1</a>  | Pauperformance | 2022-03-16   |
 
 
 
@@ -75,5 +75,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Playing Pauper: Kuldotha Boros](https://www.mtggoldfish.com/articles/playing-pauper-kuldotha-boros) | Jake Stiles | 2016-11-05   |
+| 🇬🇧 | <a target="_blank" href="https://www.mtggoldfish.com/articles/playing-pauper-kuldotha-boros">Playing Pauper: Kuldotha Boros</a>  | Jake Stiles | 2016-11-05   |
 

--- a/archetypes/Midnight Gond.md
+++ b/archetypes/Midnight Gond.md
@@ -44,8 +44,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Midnight Gond 488.002.eternalgathering](https://www.mtggoldfish.com/deck/4351087) | Modern Masters 2017 | 2017-03-17 | ✅ |
-| [Midnight Gond 488.001.eternalgathering](https://www.mtggoldfish.com/deck/4351086) | Modern Masters 2017 | 2017-03-17 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351087">Midnight Gond 488.002.eternalgathering</a>  | Modern Masters 2017 | 2017-03-17 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351086">Midnight Gond 488.001.eternalgathering</a>  | Modern Masters 2017 | 2017-03-17 | ✅ |
 
 
 
@@ -56,5 +56,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [Midnight combo, gli manca solo la pescata(?)](https://eternalgathering.altervista.org/midnight-combo-gli-manca-solo-la-pescata/) | eternalgathering | 2017-03-19   |
+| 🇮🇹 | <a target="_blank" href="https://eternalgathering.altervista.org/midnight-combo-gli-manca-solo-la-pescata/">Midnight combo, gli manca solo la pescata(?)</a>  | eternalgathering | 2017-03-19   |
 

--- a/archetypes/Moggwarts.md
+++ b/archetypes/Moggwarts.md
@@ -61,8 +61,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Moggwarts 683.001.Hamuda](https://www.mtggoldfish.com/deck/4624432) | Adventures in the Forgotten Realms | 2021-07-23 | ✅ |
-| [Moggwarts 669.001.Hamuda](https://www.mtggoldfish.com/deck/4351108) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624432">Moggwarts 683.001.Hamuda</a>  | Adventures in the Forgotten Realms | 2021-07-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351108">Moggwarts 669.001.Hamuda</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
 
 
 
@@ -71,11 +71,11 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Moggwarts 722.001.Shika93](https://www.mtggoldfish.com/deck/4680046) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Moggwarts 722.001.Kiiiittyman](https://www.mtggoldfish.com/deck/4667108) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Moggwarts 722.001.AMzobud](https://www.mtggoldfish.com/deck/4645828) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Moggwarts 669.001.pepeisra](https://www.mtggoldfish.com/deck/4351109) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Moggwarts 669.001.Milkk](https://www.mtggoldfish.com/deck/4351099) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680046">Moggwarts 722.001.Shika93</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667108">Moggwarts 722.001.Kiiiittyman</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4645828">Moggwarts 722.001.AMzobud</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351109">Moggwarts 669.001.pepeisra</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351099">Moggwarts 669.001.Milkk</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
 
 
 
@@ -84,8 +84,8 @@
 
 | 🗣️ | 📺 | Deck | Author | Date |
 | -- | -- | ---- | ------ | ---- |
-| 🇮🇹 | <i class="fa-brands fa-youtube"></i> | [Moggwarts 722.001.Shika93](https://www.youtube.com/watch?v=iTHsl8oBHG8) | Pauperformance | 2022-03-17   |
-| 🇬🇧 | <i class="fa-brands fa-youtube"></i> | [Moggwarts 722.001.AMzobud](https://www.youtube.com/watch?v=7RbDZNvio3M) | Pauperformance | 2022-03-17   |
+| 🇮🇹 | <i class="fa-brands fa-youtube"></i> | <a target="_blank" href="https://www.youtube.com/watch?v=iTHsl8oBHG8">Moggwarts 722.001.Shika93</a>  | Pauperformance | 2022-03-17   |
+| 🇬🇧 | <i class="fa-brands fa-youtube"></i> | <a target="_blank" href="https://www.youtube.com/watch?v=7RbDZNvio3M">Moggwarts 722.001.AMzobud</a>  | Pauperformance | 2022-03-17   |
 
 
 
@@ -94,5 +94,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Moggwarts Discord](https://discord.gg/hdFAKcTd) | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/hdFAKcTd">Pauper Moggwarts Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
 

--- a/archetypes/MonoB Control.md
+++ b/archetypes/MonoB Control.md
@@ -56,7 +56,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoB Control 701.001.medvedev](https://www.mtggoldfish.com/deck/4680107) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680107">MonoB Control 701.001.medvedev</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
 
 
 
@@ -65,13 +65,13 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoB Control 722.001.Venancioo](https://www.mtggoldfish.com/deck/4680111) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [MonoB Control 722.001.John1111](https://www.mtggoldfish.com/deck/4680122) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [MonoB Control 612.001.Shika93](https://www.mtggoldfish.com/deck/4680118) | Theros Beyond Death | 2020-01-24 | ✅ |
-| [MonoB Control 597.002.Shika93](https://www.mtggoldfish.com/deck/4680117) | Commander 2019 | 2019-08-23 | ✅ |
-| [MonoB Control 597.001.Shika93](https://www.mtggoldfish.com/deck/4680115) | Commander 2019 | 2019-08-23 | ✅ |
-| [MonoB Control 584.001.Shika93](https://www.mtggoldfish.com/deck/4680114) | War of the Spark | 2019-05-03 | ✅ |
-| [MonoB Control 537.001.Shika93](https://www.mtggoldfish.com/deck/4680113) | Dominaria | 2018-04-27 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680111">MonoB Control 722.001.Venancioo</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680122">MonoB Control 722.001.John1111</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680118">MonoB Control 612.001.Shika93</a>  | Theros Beyond Death | 2020-01-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680117">MonoB Control 597.002.Shika93</a>  | Commander 2019 | 2019-08-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680115">MonoB Control 597.001.Shika93</a>  | Commander 2019 | 2019-08-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680114">MonoB Control 584.001.Shika93</a>  | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680113">MonoB Control 537.001.Shika93</a>  | Dominaria | 2018-04-27 | ✅ |
 
 
 

--- a/archetypes/MonoB Ponza.md
+++ b/archetypes/MonoB Ponza.md
@@ -39,8 +39,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoB Ponza 651.001.Bardo](https://www.mtggoldfish.com/deck/4673178) | Commander Legends | 2020-11-20 | ✅ |
-| [MonoB Ponza 540.001.Shika93](https://www.mtggoldfish.com/deck/4351754) | Battlebond | 2018-06-08 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673178">MonoB Ponza 651.001.Bardo</a>  | Commander Legends | 2020-11-20 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351754">MonoB Ponza 540.001.Shika93</a>  | Battlebond | 2018-06-08 | ✅ |
 
 
 

--- a/archetypes/MonoB Suicide.md
+++ b/archetypes/MonoB Suicide.md
@@ -56,8 +56,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoB Suicide 722.001.Haste_BR](https://www.mtggoldfish.com/deck/4673179) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [MonoB Suicide 584.001.Lazoreoc](https://www.mtggoldfish.com/deck/4351098) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673179">MonoB Suicide 722.001.Haste_BR</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351098">MonoB Suicide 584.001.Lazoreoc</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 

--- a/archetypes/MonoG Ponza.md
+++ b/archetypes/MonoG Ponza.md
@@ -20,7 +20,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoG Ponza 600.001.Mazurin_Pavel](https://www.mtggoldfish.com/deck/4673161) | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673161">MonoG Ponza 600.001.Mazurin_Pavel</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
 
 
 

--- a/archetypes/MonoG Tron.md
+++ b/archetypes/MonoG Tron.md
@@ -52,8 +52,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoG Tron 722.001.VINICIUS](https://www.mtggoldfish.com/deck/4673165) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [MonoG Tron 442.001.Don](https://www.mtggoldfish.com/deck/4673163) | Battle for Zendikar | 2015-10-02 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673165">MonoG Tron 722.001.VINICIUS</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673163">MonoG Tron 442.001.Don</a>  | Battle for Zendikar | 2015-10-02 | Ban 🔨 |
 
 
 

--- a/archetypes/MonoU Faeries.md
+++ b/archetypes/MonoU Faeries.md
@@ -51,7 +51,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoU Faeries 696.001.Drugo](https://www.mtggoldfish.com/deck/4624381) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624381">MonoU Faeries 696.001.Drugo</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
 
 
 
@@ -60,8 +60,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoU Faeries 722.001.MonoU Faeries](https://www.mtggoldfish.com/deck/4667107) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [MonoU Faeries 540.001.Shika93](https://www.mtggoldfish.com/deck/4351740) | Battlebond | 2018-06-08 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667107">MonoU Faeries 722.001.MonoU Faeries</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351740">MonoU Faeries 540.001.Shika93</a>  | Battlebond | 2018-06-08 | Ban 🔨 |
 
 
 
@@ -72,5 +72,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [[Pauper Tier] Mono Blue Delver](http://www.metagame.it/forum/viewtopic.php?f=158&t=265) | Scrocchi | 2011-09-27   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=158&t=265">[Pauper Tier] Mono Blue Delver</a>  | Scrocchi | 2011-09-27   |
 

--- a/archetypes/MonoW Heroic.md
+++ b/archetypes/MonoW Heroic.md
@@ -48,8 +48,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoW Heroic 696.001.Raven094](https://www.mtggoldfish.com/deck/4624436) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
-| [MonoW Heroic 651.001.Mathonical](https://www.mtggoldfish.com/deck/4351125) | Commander Legends | 2020-11-20 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624436">MonoW Heroic 696.001.Raven094</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351125">MonoW Heroic 651.001.Mathonical</a>  | Commander Legends | 2020-11-20 | ✅ |
 
 
 
@@ -58,8 +58,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [MonoW Heroic 722.001.kalko](https://www.mtggoldfish.com/deck/4667109) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [MonoW Heroic 584.001.dhalsinbh1](https://www.mtggoldfish.com/deck/4351061) | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667109">MonoW Heroic 722.001.kalko</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351061">MonoW Heroic 584.001.dhalsinbh1</a>  | War of the Spark | 2019-05-03 | ✅ |
 
 
 
@@ -70,5 +70,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [A Pauper Primer to Mono W Heroic](https://ravennonest.wordpress.com/2021/10/17/a-pauper-primer-to-mono-w-heroic/) | Raven | 2021-10-17   |
+| 🇬🇧 | <a target="_blank" href="https://ravennonest.wordpress.com/2021/10/17/a-pauper-primer-to-mono-w-heroic/">A Pauper Primer to Mono W Heroic</a>  | Raven | 2021-10-17   |
 

--- a/archetypes/Myr Retriever Combo.md
+++ b/archetypes/Myr Retriever Combo.md
@@ -20,7 +20,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Myr Retriever Combo 722.001.Shika93](https://www.mtggoldfish.com/deck/4675388) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4675388">Myr Retriever Combo 722.001.Shika93</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 

--- a/archetypes/One Land Spy.md
+++ b/archetypes/One Land Spy.md
@@ -60,7 +60,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [One Land Spy 658.001.BluStalker](https://www.mtggoldfish.com/deck/4624301) | Kaldheim | 2021-02-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624301">One Land Spy 658.001.BluStalker</a>  | Kaldheim | 2021-02-05 | ✅ |
 
 
 
@@ -69,8 +69,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [One Land Spy 537.001.Miura Akiyoshi](https://www.mtggoldfish.com/deck/4351112) | Dominaria | 2018-04-27 | Ban 🔨 |
-| [One Land Spy 433.001.Matteo Burello](https://www.mtggoldfish.com/deck/4351111) | Modern Masters 2015 | 2015-05-22 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351112">One Land Spy 537.001.Miura Akiyoshi</a>  | Dominaria | 2018-04-27 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351111">One Land Spy 433.001.Matteo Burello</a>  | Modern Masters 2015 | 2015-05-22 | Ban 🔨 |
 
 
 
@@ -81,5 +81,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [PAUPER DECK ANALISI - BALUSTRADE COMBO](http://www.metagame.it/articoli-pauper/2261-pauper-deck-analisi-one-land-one-shot.html) | Matteo Burello | 2015-05-24   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/articoli-pauper/2261-pauper-deck-analisi-one-land-one-shot.html">PAUPER DECK ANALISI - BALUSTRADE COMBO</a>  | Matteo Burello | 2015-05-24   |
 

--- a/archetypes/Orzhov Pestilence.md
+++ b/archetypes/Orzhov Pestilence.md
@@ -71,8 +71,8 @@ The deck is sometimes considered unstable due to the high number of lands it req
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Orzhov Pestilence 696.001.Kampo](https://www.mtggoldfish.com/deck/4624375) | Innistrad: Midnight Hunt | 2021-09-24 | Ban 🔨 |
-| [Orzhov Pestilence 572.001.Amoras27](https://www.mtggoldfish.com/deck/4618609) | Ultimate Masters | 2018-12-07 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624375">Orzhov Pestilence 696.001.Kampo</a>  | Innistrad: Midnight Hunt | 2021-09-24 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618609">Orzhov Pestilence 572.001.Amoras27</a>  | Ultimate Masters | 2018-12-07 | ✅ |
 
 
 
@@ -81,8 +81,8 @@ The deck is sometimes considered unstable due to the high number of lands it req
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Orzhov Pestilence 584.001.Shika93](https://www.mtggoldfish.com/deck/4351746) | War of the Spark | 2019-05-03 | ✅ |
-| [Orzhov Pestilence 572.001.donzauker84](https://www.mtggoldfish.com/deck/4618593) | Ultimate Masters | 2018-12-07 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351746">Orzhov Pestilence 584.001.Shika93</a>  | War of the Spark | 2019-05-03 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618593">Orzhov Pestilence 572.001.donzauker84</a>  | Ultimate Masters | 2018-12-07 | Ban 🔨 |
 
 
 
@@ -93,6 +93,6 @@ The deck is sometimes considered unstable due to the high number of lands it req
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pestilence: What You Have to Endure, What You Have to Put Others Through](https://www.coolstuffinc.com/a/kendrasmith-12262018-pestilence-what-you-have-to-endure-what-you-have-to-put-others-through) | Paige Smith | 2018-12-26   |
-| 🇮🇹 | [[Pauper Tier] Orzhov Pestilence](http://www.metagame.it/forum/viewtopic.php?f=158&t=26084) | Pentola | 2018-05-21   |
+| 🇬🇧 | <a target="_blank" href="https://www.coolstuffinc.com/a/kendrasmith-12262018-pestilence-what-you-have-to-endure-what-you-have-to-put-others-through">Pestilence: What You Have to Endure, What You Have to Put Others Through</a>  | Paige Smith | 2018-12-26   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=158&t=26084">[Pauper Tier] Orzhov Pestilence</a>  | Pentola | 2018-05-21   |
 

--- a/archetypes/Petal Festival.md
+++ b/archetypes/Petal Festival.md
@@ -55,7 +55,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Petal Festival 669.001.saidin.rake](https://www.mtggoldfish.com/deck/4351110) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351110">Petal Festival 669.001.saidin.rake</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
 
 
 
@@ -64,7 +64,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Petal Festival 658.001.MTGDelphi](https://www.mtggoldfish.com/deck/4351106) | Kaldheim | 2021-02-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351106">Petal Festival 658.001.MTGDelphi</a>  | Kaldheim | 2021-02-05 | ✅ |
 
 
 

--- a/archetypes/Ping Storm.md
+++ b/archetypes/Ping Storm.md
@@ -39,8 +39,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Ping Storm 722.001.Raptor56](https://www.mtggoldfish.com/deck/4643658) | Kamigawa: Neon Dynasty | 2022-02-18 | Ban 🔨 |
-| [Ping Storm 722.001.Mikhathara1994](https://www.mtggoldfish.com/deck/4667100) | Kamigawa: Neon Dynasty | 2022-02-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4643658">Ping Storm 722.001.Raptor56</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667100">Ping Storm 722.001.Mikhathara1994</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | Ban 🔨 |
 
 
 
@@ -51,5 +51,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Storm Discord](https://discord.gg/zrn2N6HT) | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/zrn2N6HT">Pauper Storm Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
 

--- a/archetypes/Rakdos Burn.md
+++ b/archetypes/Rakdos Burn.md
@@ -49,8 +49,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Rakdos Burn 722.001.rfaustino](https://www.mtggoldfish.com/deck/4667114) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Rakdos Burn 722.001.DaveXXXVI](https://www.mtggoldfish.com/deck/4667103) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667114">Rakdos Burn 722.001.rfaustino</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667103">Rakdos Burn 722.001.DaveXXXVI</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 

--- a/archetypes/Rakdos Control.md
+++ b/archetypes/Rakdos Control.md
@@ -48,7 +48,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Rakdos Control 540.001.Bruno dos Santos Silva](https://www.mtggoldfish.com/deck/4351050) | Battlebond | 2018-06-08 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351050">Rakdos Control 540.001.Bruno dos Santos Silva</a>  | Battlebond | 2018-06-08 | ✅ |
 
 
 
@@ -57,7 +57,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Rakdos Control 658.001.Topsy](https://www.mtggoldfish.com/deck/4673158) | Kaldheim | 2021-02-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673158">Rakdos Control 658.001.Topsy</a>  | Kaldheim | 2021-02-05 | ✅ |
 
 
 

--- a/archetypes/Rakdos Madness.md
+++ b/archetypes/Rakdos Madness.md
@@ -22,7 +22,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Rakdos Madness 722.001.Cesta](https://www.mtggoldfish.com/deck/4667102) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667102">Rakdos Madness 722.001.Cesta</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 

--- a/archetypes/Rakdos Reanimator.md
+++ b/archetypes/Rakdos Reanimator.md
@@ -53,8 +53,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Rakdos Reanimator 669.001.OlavoJusMTM](https://www.mtggoldfish.com/deck/4351132) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Rakdos Reanimator 669.001.Gorlewski](https://www.mtggoldfish.com/deck/4351131) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351132">Rakdos Reanimator 669.001.OlavoJusMTM</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351131">Rakdos Reanimator 669.001.Gorlewski</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
 
 
 

--- a/archetypes/Rakdos TortEx.md
+++ b/archetypes/Rakdos TortEx.md
@@ -53,9 +53,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Rakdos TortEx 683.002.Shika93](https://www.mtggoldfish.com/deck/4351759) | Adventures in the Forgotten Realms | 2021-07-23 | ✅ |
-| [Rakdos TortEx 683.001.Shika93](https://www.mtggoldfish.com/deck/4351758) | Adventures in the Forgotten Realms | 2021-07-23 | ✅ |
-| [Rakdos TortEx 518.001.Fran Blanco](https://www.mtggoldfish.com/deck/4351049) | Iconic Masters | 2017-11-17 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351759">Rakdos TortEx 683.002.Shika93</a>  | Adventures in the Forgotten Realms | 2021-07-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351758">Rakdos TortEx 683.001.Shika93</a>  | Adventures in the Forgotten Realms | 2021-07-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351049">Rakdos TortEx 518.001.Fran Blanco</a>  | Iconic Masters | 2017-11-17 | ✅ |
 
 
 
@@ -66,5 +66,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper TortEx Discord](https://discord.gg/fRzwk2TJ) | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/fRzwk2TJ">Pauper TortEx Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
 

--- a/archetypes/Red Deck Wins.md
+++ b/archetypes/Red Deck Wins.md
@@ -47,8 +47,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Red Deck Wins 722.001.TiagoFuguete](https://www.mtggoldfish.com/deck/4673156) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Red Deck Wins 701.001.OlavoJusMTM](https://www.mtggoldfish.com/deck/4673157) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673156">Red Deck Wins 722.001.TiagoFuguete</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673157">Red Deck Wins 701.001.OlavoJusMTM</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
 
 
 
@@ -59,5 +59,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [Report Pauper - Winner @ Paupergeddon 2019 con RDW](http://www.metagame.it/articoli-pauper/3514-report-pauper-winner-paupergeddon-2019-con-rdw.html) | Matteo Mentasti | 2019-02-24   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/articoli-pauper/3514-report-pauper-winner-paupergeddon-2019-con-rdw.html">Report Pauper - Winner @ Paupergeddon 2019 con RDW</a>  | Matteo Mentasti | 2019-02-24   |
 

--- a/archetypes/Slivers.md
+++ b/archetypes/Slivers.md
@@ -52,7 +52,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Slivers 651.001.Esandrad](https://www.mtggoldfish.com/deck/4624340) | Commander Legends | 2020-11-20 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624340">Slivers 651.001.Esandrad</a>  | Commander Legends | 2020-11-20 | ✅ |
 
 
 
@@ -61,10 +61,10 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Slivers 600.001.gannoncd](https://www.mtggoldfish.com/deck/4626275) | Throne of Eldraine | 2019-10-04 | ✅ |
-| [Slivers 600.001.HANSDAMPF](https://www.mtggoldfish.com/deck/4351097) | Throne of Eldraine | 2019-10-04 | ✅ |
-| [Slivers 590.001.gannoncd](https://www.mtggoldfish.com/deck/4626276) | Core Set 2020 | 2019-07-12 | ✅ |
-| [Slivers 560.001.frucile](https://www.mtggoldfish.com/deck/4626277) | Guilds of Ravnica | 2018-10-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4626275">Slivers 600.001.gannoncd</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351097">Slivers 600.001.HANSDAMPF</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4626276">Slivers 590.001.gannoncd</a>  | Core Set 2020 | 2019-07-12 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4626277">Slivers 560.001.frucile</a>  | Guilds of Ravnica | 2018-10-05 | ✅ |
 
 
 
@@ -75,5 +75,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [[Pauper Tier] Slivers](http://www.metagame.it/forum/viewtopic.php?f=158&t=5888) | Kuraiden | 2012-05-17   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=158&t=5888">[Pauper Tier] Slivers</a>  | Kuraiden | 2012-05-17   |
 

--- a/archetypes/Soul Sisters.md
+++ b/archetypes/Soul Sisters.md
@@ -46,7 +46,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Soul Sisters 600.002.gannoncd](https://www.mtggoldfish.com/deck/4351090) | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351090">Soul Sisters 600.002.gannoncd</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
 
 
 
@@ -55,7 +55,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Soul Sisters 600.001.gannoncd](https://www.mtggoldfish.com/deck/4351092) | Throne of Eldraine | 2019-10-04 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351092">Soul Sisters 600.001.gannoncd</a>  | Throne of Eldraine | 2019-10-04 | ✅ |
 
 
 

--- a/archetypes/Stompy.md
+++ b/archetypes/Stompy.md
@@ -52,8 +52,8 @@ Since 2019, the addition of [Savage Swipe](https://scryfall.com/card/mh1/178/sav
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Stompy 722.001.tarmogoyf_ita](https://www.mtggoldfish.com/deck/4680163) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Stompy 696.001.Ixidor29](https://www.mtggoldfish.com/deck/4624367) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4680163">Stompy 722.001.tarmogoyf_ita</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624367">Stompy 696.001.Ixidor29</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
 
 
 
@@ -62,9 +62,9 @@ Since 2019, the addition of [Savage Swipe](https://scryfall.com/card/mh1/178/sav
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Stompy 722.001.thuriborghez](https://www.mtggoldfish.com/deck/4667104) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Stompy 669.001.Shika93](https://www.mtggoldfish.com/deck/4351732) | Strixhaven: School of Mages | 2021-04-23 | ✅ |
-| [Stompy 537.001.Shika93](https://www.mtggoldfish.com/deck/4351739) | Dominaria | 2018-04-27 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667104">Stompy 722.001.thuriborghez</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351732">Stompy 669.001.Shika93</a>  | Strixhaven: School of Mages | 2021-04-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351739">Stompy 537.001.Shika93</a>  | Dominaria | 2018-04-27 | ✅ |
 
 
 
@@ -75,10 +75,10 @@ Since 2019, the addition of [Savage Swipe](https://scryfall.com/card/mh1/178/sav
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Stompy Discord](https://discord.gg/RzTmb76qjJ) | <i class="fa-brands fa-discord"></i> | ~            |
-| 🇬🇧 | [Pauper Stompy Deck Guide](https://strategy.channelfireball.com/all-strategy/mtg/channelmagic-articles/pauper-stompy-deck-guide/) | Alex Ullman | 2020-08-27   |
-| 🇬🇧 | [Bringing Back Pauper Stompy](https://www.coolstuffinc.com/a/kendrasmith-11212018-bringing-back-pauper-stompy) | Paige Smith | 2018-11-21   |
-| 🇬🇧 | [Mono Green Stompy Pauper Guide](https://teamhp555130435.wordpress.com/2018/10/26/mono-green-stompy-pauper-guide/) | airborne17th | 2018-10-26   |
-| 🇮🇹 | [[PAUPER PRIMER] Mono Green](http://www.metagame.it/forum/viewtopic.php?f=187&t=10786) | Mr Pain | 2013-12-24   |
-| 🇬🇧 | [[Primer] Mono Green Aggro (stompy)](https://www.mtgsalvation.com/forums/the-game/pauper/mtgo-pauper/established/189724-primer-mono-green-aggro-stompy) | Psychobabble | 2013-10-17   |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/RzTmb76qjJ">Pauper Stompy Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://strategy.channelfireball.com/all-strategy/mtg/channelmagic-articles/pauper-stompy-deck-guide/">Pauper Stompy Deck Guide</a>  | Alex Ullman | 2020-08-27   |
+| 🇬🇧 | <a target="_blank" href="https://www.coolstuffinc.com/a/kendrasmith-11212018-bringing-back-pauper-stompy">Bringing Back Pauper Stompy</a>  | Paige Smith | 2018-11-21   |
+| 🇬🇧 | <a target="_blank" href="https://teamhp555130435.wordpress.com/2018/10/26/mono-green-stompy-pauper-guide/">Mono Green Stompy Pauper Guide</a>  | airborne17th | 2018-10-26   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/forum/viewtopic.php?f=187&t=10786">[PAUPER PRIMER] Mono Green</a>  | Mr Pain | 2013-12-24   |
+| 🇬🇧 | <a target="_blank" href="https://www.mtgsalvation.com/forums/the-game/pauper/mtgo-pauper/established/189724-primer-mono-green-aggro-stompy">[Primer] Mono Green Aggro (stompy)</a>  | Psychobabble | 2013-10-17   |
 

--- a/archetypes/Temur Cascade.md
+++ b/archetypes/Temur Cascade.md
@@ -51,9 +51,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Temur Cascade 696.002.Shika93](https://www.mtggoldfish.com/deck/4679974) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
-| [Temur Cascade 696.001.Shika93](https://www.mtggoldfish.com/deck/4353988) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
-| [Temur Cascade 696.001.CooperTheRed](https://www.mtggoldfish.com/deck/4353987) | Innistrad: Midnight Hunt | 2021-09-24 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4679974">Temur Cascade 696.002.Shika93</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4353988">Temur Cascade 696.001.Shika93</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4353987">Temur Cascade 696.001.CooperTheRed</a>  | Innistrad: Midnight Hunt | 2021-09-24 | Ban 🔨 |
 
 
 
@@ -62,8 +62,8 @@
 
 | 🗣️ | 📺 | Deck | Author | Date |
 | -- | -- | ---- | ------ | ---- |
-| 🇮🇹 | <i class="fa-brands fa-youtube"></i> | [Temur Cascade 696.002.Shika93](https://www.youtube.com/watch?v=St6w7MTBabQ) | Pauperformance | 2022-03-20   |
-| 🇮🇹 | <i class="fa-brands fa-youtube"></i> | [Temur Cascade 696.002.Shika93](https://www.youtube.com/watch?v=yocuMcUPGBA) | Pauperformance | 2022-03-17   |
+| 🇮🇹 | <i class="fa-brands fa-youtube"></i> | <a target="_blank" href="https://www.youtube.com/watch?v=St6w7MTBabQ">Temur Cascade 696.002.Shika93</a> | Pauperformance | 2022-03-20   |
+| 🇮🇹 | <i class="fa-brands fa-youtube"></i> | <a target="_blank" href="https://www.youtube.com/watch?v=yocuMcUPGBA">Temur Cascade 696.002.Shika93</a>  | Pauperformance | 2022-03-17   |
 
 
 
@@ -72,5 +72,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Cascade Discord](https://discord.gg/2qf7KsVE) | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/2qf7KsVE">Pauper Cascade Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
 

--- a/archetypes/Turbofog.md
+++ b/archetypes/Turbofog.md
@@ -22,7 +22,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Turbofog 722.001.wisanto](https://www.mtggoldfish.com/deck/4673166) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4673166">Turbofog 722.001.wisanto</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
 
 
 
@@ -33,5 +33,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [[Primer] Turbo Fog](https://www.mtgnexus.com/viewtopic.php?f=80&t=564) | Spell_Slam | 2019-07-12   |
+| 🇬🇧 | <a target="_blank" href="https://www.mtgnexus.com/viewtopic.php?f=80&t=564">[Primer] Turbo Fog</a>  | Spell_Slam | 2019-07-12   |
 

--- a/archetypes/Walls.md
+++ b/archetypes/Walls.md
@@ -70,9 +70,9 @@ A hybrid version of the two exists, with main deck cascade that can transform in
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Walls 722.001.apas72](https://www.mtggoldfish.com/deck/4667270) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [Walls 696.001.HouseOfManaMTG](https://www.mtggoldfish.com/deck/4624355) | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
-| [Walls 658.001.Mathonical](https://www.mtggoldfish.com/deck/4351126) | Kaldheim | 2021-02-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667270">Walls 722.001.apas72</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4624355">Walls 696.001.HouseOfManaMTG</a>  | Innistrad: Midnight Hunt | 2021-09-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351126">Walls 658.001.Mathonical</a>  | Kaldheim | 2021-02-05 | ✅ |
 
 
 
@@ -81,9 +81,9 @@ A hybrid version of the two exists, with main deck cascade that can transform in
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Walls 701.001.Terminus0](https://www.mtggoldfish.com/deck/4667272) | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
-| [Walls 658.001.NotGood](https://www.mtggoldfish.com/deck/4667271) | Kaldheim | 2021-02-05 | ✅ |
-| [Walls 612.001.Diego_Brando](https://www.mtggoldfish.com/deck/4351100) | Theros Beyond Death | 2020-01-24 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667272">Walls 701.001.Terminus0</a>  | Innistrad: Crimson Vow | 2021-11-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667271">Walls 658.001.NotGood</a>  | Kaldheim | 2021-02-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351100">Walls 612.001.Diego_Brando</a>  | Theros Beyond Death | 2020-01-24 | ✅ |
 
 
 
@@ -94,7 +94,7 @@ A hybrid version of the two exists, with main deck cascade that can transform in
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Walls Discord](https://discord.gg/p4kESAk) | <i class="fa-brands fa-discord"></i> | ~            |
-| 🇬🇧 | [Pauper Walls Combo](https://www.legapauperonline.com/pauper-walls-combo/) | Andrea Passaro | 2022-03-11   |
-| 🇬🇧 | [Anyway, Here's Wonderwalls](https://www.coolstuffinc.com/a/kendrasmith-02122020-anyway-heres-wonderwalls) | Paige Smith | 2020-02-12   |
+| 🇬🇧 | <a target="_blank" href="https://discord.gg/p4kESAk">Pauper Walls Discord</a>  | <i class="fa-brands fa-discord"></i> | ~            |
+| 🇬🇧 | <a target="_blank" href="https://www.legapauperonline.com/pauper-walls-combo/">Pauper Walls Combo</a>  | Andrea Passaro | 2022-03-11   |
+| 🇬🇧 | <a target="_blank" href="https://www.coolstuffinc.com/a/kendrasmith-02122020-anyway-heres-wonderwalls">Anyway, Here's Wonderwalls</a>  | Paige Smith | 2020-02-12   |
 

--- a/archetypes/Watch Rites.md
+++ b/archetypes/Watch Rites.md
@@ -51,9 +51,9 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Watch Rites 560.001.Leonardo Borghi](https://www.mtggoldfish.com/deck/4351081) | Guilds of Ravnica | 2018-10-05 | ✅ |
-| [Watch Rites 488.001.eternalgathering](https://www.mtggoldfish.com/deck/4352004) | Modern Masters 2017 | 2017-03-17 | Ban 🔨 |
-| [Watch Rites 424.001.Matteo Burello](https://www.mtggoldfish.com/deck/4351141) | Fate Reforged | 2015-01-23 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351081">Watch Rites 560.001.Leonardo Borghi</a>  | Guilds of Ravnica | 2018-10-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4352004">Watch Rites 488.001.eternalgathering</a>  | Modern Masters 2017 | 2017-03-17 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351141">Watch Rites 424.001.Matteo Burello</a>  | Fate Reforged | 2015-01-23 | ✅ |
 
 
 
@@ -64,7 +64,7 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [[Pauper] Temur Watch Rites by Leonardo Borghi](http://www.magictitans.it/pauper-temur-watch-rites-by-leonardo-borghi/) | Leonardo Borghi | 2018-12-06   |
-| 🇮🇹 | [Watch Rites combo – il lupo travestito da agnello](https://eternalgathering.altervista.org/watch-rites-combo/) | eternalgathering | 2017-04-18   |
-| 🇮🇹 | [Pauper Deck Analisi - RUG Watch Rites](http://www.metagame.it/articoli-pauper/1957-pauper-deck-analisi-rug-watch-rites.html) | Matteo Burello | 2015-02-05   |
+| 🇮🇹 | <a target="_blank" href="http://www.magictitans.it/pauper-temur-watch-rites-by-leonardo-borghi/">[Pauper] Temur Watch Rites by Leonardo Borghi</a>  | Leonardo Borghi | 2018-12-06   |
+| 🇮🇹 | <a target="_blank" href="https://eternalgathering.altervista.org/watch-rites-combo/">Watch Rites combo – il lupo travestito da agnello</a>  | eternalgathering | 2017-04-18   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/articoli-pauper/1957-pauper-deck-analisi-rug-watch-rites.html">Pauper Deck Analisi - RUG Watch Rites</a>  | Matteo Burello | 2015-02-05   |
 

--- a/archetypes/Whirlpool Mill.md
+++ b/archetypes/Whirlpool Mill.md
@@ -47,8 +47,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Whirlpool Mill 518.001.JherjamesB](https://www.mtggoldfish.com/deck/4618672) | Iconic Masters | 2017-11-17 | Ban 🔨 |
-| [Whirlpool Mill 442.001.Milkk](https://www.mtggoldfish.com/deck/4620518) | Battle for Zendikar | 2015-10-02 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618672">Whirlpool Mill 518.001.JherjamesB</a>  | Iconic Masters | 2017-11-17 | Ban 🔨 |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4620518">Whirlpool Mill 442.001.Milkk</a>  | Battle for Zendikar | 2015-10-02 | Ban 🔨 |
 
 
 
@@ -59,5 +59,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇬🇧 | [Pauper Ponderings: Whirlpool Mill](https://themanabase.com/pauper-ponderings-whirlpool-mill/) | Austen Hoey | 2016-11-03   |
+| 🇬🇧 | <a target="_blank" href="https://themanabase.com/pauper-ponderings-whirlpool-mill/">Pauper Ponderings: Whirlpool Mill</a>  | Austen Hoey | 2016-11-03   |
 

--- a/archetypes/White Weenie.md
+++ b/archetypes/White Weenie.md
@@ -53,8 +53,8 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [White Weenie 722.001.TheChronicle](https://www.mtggoldfish.com/deck/4667105) | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
-| [White Weenie 447.001.Matteo Burello](https://www.mtggoldfish.com/deck/4351101) | Commander 2015 | 2015-11-13 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4667105">White Weenie 722.001.TheChronicle</a>  | Kamigawa: Neon Dynasty | 2022-02-18 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4351101">White Weenie 447.001.Matteo Burello</a>  | Commander 2015 | 2015-11-13 | ✅ |
 
 
 
@@ -65,5 +65,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [PAUPER DECK ANALISI - WHITE WEENIE, OLD BUT GOLD](http://www.metagame.it/articoli-pauper/2543-pauper-deck-analisi-white-weenie.html) | Matteo Burello | 2015-11-27   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/articoli-pauper/2543-pauper-deck-analisi-white-weenie.html">PAUPER DECK ANALISI - WHITE WEENIE, OLD BUT GOLD</a>  | Matteo Burello | 2015-11-27   |
 

--- a/archetypes/Zubera Storm.md
+++ b/archetypes/Zubera Storm.md
@@ -45,7 +45,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Zubera Storm 658.001.MTGDelphi](https://www.mtggoldfish.com/deck/4618707) | Kaldheim | 2021-02-05 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618707">Zubera Storm 658.001.MTGDelphi</a>  | Kaldheim | 2021-02-05 | ✅ |
 
 
 
@@ -54,7 +54,7 @@
 
 | Name | Set name | Set date | Legal |
 | -----| -------- | -------- | ----- |
-| [Zubera Storm 529.001.Størm](https://www.mtggoldfish.com/deck/4618698) | Rivals of Ixalan | 2018-01-19 | ✅ |
+| <a target="_blank" href="https://www.mtggoldfish.com/deck/4618698">Zubera Storm 529.001.Størm</a>  | Rivals of Ixalan | 2018-01-19 | ✅ |
 
 
 
@@ -65,5 +65,5 @@
 
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
-| 🇮🇹 | [Building on a budget: Pauper Dimir Zubera](http://www.metagame.it/articoli-pauper/3378-building-on-a-budget-pauper-dimir-zubera.html) | Roberto Bernocco | 2018-06-07   |
+| 🇮🇹 | <a target="_blank" href="http://www.metagame.it/articoli-pauper/3378-building-on-a-budget-pauper-dimir-zubera.html">Building on a budget: Pauper Dimir Zubera</a>  | Roberto Bernocco | 2018-06-07   |
 


### PR DESCRIPTION
I used this script to change the links
```bash
#!/bin/bash

find_expr='\| \[\(.*\)\](\(http.*\))\(.*\)$'
expr="s|$find_expr|\| <a target=\"_blank\" href=\"\2\">\1</a> \3|g"
echo "$expr"
for p in archetypes/*.md; do
    echo "Updating: $p"
    sed -i -e "$expr" "$p"
done
```
and this one to test the links are ok
```bash
#!/bin/bash

lnk_expr='https://www.mtggoldfish.com/deck/.*'
find_expr=".*href=\"$lnk_expr"
echo "$find_expr"
for p in archetypes/*.md; do
    echo "$p" | grep "Boros\ Metalcraft.md"
    if [ $? = 0 ]; then
        echo "Skipping: $p"
        continue
    fi
    echo "Checking: $p"
    count=0
    for lnk in $(egrep -o "$find_expr" "$p" | sed -e "s|.*href=\"*\($lnk_expr\)\".*|\1|"); do
        count=$((count+1))
        echo "link: $lnk"
        curl -H "Accept: text/html" --head -fqsS "$lnk" 2>&1 1>/dev/null
        if [ $? = 0 ]; then
            echo "OK: $lnk"
        else
            echo "ERROR: '$p' $lnk"
            exit 1
        fi
    done
    if [ $count = 0 ]; then
        echo "ERROR: no links found"
        exit 1
    fi
done
```